### PR TITLE
:sparkles: Implement `getKeys` to return all possible keys of `OutputTemplate`

### DIFF
--- a/output/src/models/OutputTemplate.ts
+++ b/output/src/models/OutputTemplate.ts
@@ -3,6 +3,10 @@ import { OutputTemplateBase } from './OutputTemplateBase';
 import { OutputTemplatePlatforms } from './OutputTemplatePlatforms';
 
 export class OutputTemplate extends OutputTemplateBase {
+  static getKeys(): Array<keyof OutputTemplate> {
+    return ['message', 'reprompt', 'listen', 'quickReplies', 'card', 'carousel', 'platforms'];
+  }
+
   @IsOptional()
   @IsInstance(OutputTemplatePlatforms)
   @ValidateNested()


### PR DESCRIPTION
This is useful to distinguish between keys of `OutputTemplate` and other keys in an object.