### PR TITLE
✨ Add optional `permissions`-property to Alexa-`Card`

### DIFF
--- a/output-alexa/src/models/card/Card.ts
+++ b/output-alexa/src/models/card/Card.ts
@@ -1,4 +1,13 @@
-import { Card as BaseCard, EnumLike, IsEnum, Type } from '@jovotech/output';
+import {
+  Card as BaseCard,
+  IsOptional,
+  EnumLike,
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsString,
+  Type,
+} from '@jovotech/output';
 import { IsValidCardImage } from '../../decorators/validation/IsValidCardImage';
 import { IsValidCardString } from '../../decorators/validation/IsValidCardString';
 import { CardImage } from './CardImage';
@@ -11,6 +20,22 @@ export enum CardType {
 }
 
 export type CardTypeLike = EnumLike<CardType>;
+
+export enum PermissionScope {
+  ReadProfileName = 'alexa::profile:name:read',
+  ReadProfileGivenName = 'alexa::profile:given_name:read',
+  ReadProfileEmail = 'alexa::profile:email:read',
+  ReadProfileMobileNumber = 'alexa::profile:mobile_number:read',
+  ReadWriteReminders = 'alexa::alerts:reminders:skill:readwrite',
+  ReadWriteTimers = 'alexa::alerts:timers:skill:readwrite',
+  ReadList = 'read::alexa:household:list',
+  WriteList = 'write::alexa:household:list',
+  ReadAddressAll = 'read::alexa:device:all:address',
+  ReadAddressCountryAndPostalCode = 'read::alexa:device:all:address:country_and_postal_code',
+  ReadGeolocation = 'alexa::devices:all:geolocation:read',
+}
+
+export type PermissionScopeLike = EnumLike<PermissionScope> | string;
 
 export class Card<TYPE extends CardTypeLike = CardTypeLike> {
   @IsEnum(CardType)
@@ -30,6 +55,12 @@ export class Card<TYPE extends CardTypeLike = CardTypeLike> {
   image?: TYPE extends CardType.Simple | CardType.LinkAccount | CardType.AskForPermissionsConsent
     ? never
     : CardImage | undefined;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  permissions?: PermissionScopeLike[];
 
   toCard?(): BaseCard {
     const card: BaseCard = {

--- a/output-alexa/src/models/card/Card.ts
+++ b/output-alexa/src/models/card/Card.ts
@@ -30,7 +30,7 @@ export enum PermissionScope {
   ReadWriteTimers = 'alexa::alerts:timers:skill:readwrite',
   ReadList = 'read::alexa:household:list',
   WriteList = 'write::alexa:household:list',
-  ReadAddressAll = 'read::alexa:device:all:address',
+  ReadAddressFull = 'read::alexa:device:all:address',
   ReadAddressCountryAndPostalCode = 'read::alexa:device:all:address:country_and_postal_code',
   ReadGeolocation = 'alexa::devices:all:geolocation:read',
 }


### PR DESCRIPTION
Add optional `permission`-property to `Card` in `@jovotech/output-alexa`.
Also, define potential permission scopes but also support custom permission scopes.

Personally, I am not sure whether we should call the `PermissionScope` to get the address `ReadAddressAll` (current state) or rename it to `ReadAddress`.