### PR TITLE
Possible approach for richAudio output type

### DIFF
--- a/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
+++ b/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
@@ -64,8 +64,13 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
       }
     }
 
+    const richAudio = output.platforms?.Alexa?.richAudio || output.richAudio;
+    if (richAudio) {
+      addToDirectives(richAudio.toAplA?.() as AplRenderDocumentDirective);
+    }
+
     const message = output.platforms?.Alexa?.message || output.message;
-    if (message) {
+    if (message && !richAudio) {
       response.response.outputSpeech = this.convertMessageToOutputSpeech(message);
     }
 

--- a/output-alexa/src/index.ts
+++ b/output-alexa/src/index.ts
@@ -10,6 +10,12 @@ import {
 } from './models';
 import { augmentModelPrototypes } from './utilities';
 
+declare module '@jovotech/output/dist/types/models/RichAudio' {
+  interface RichAudio {
+    toApla?(): AplRenderDocumentDirective;
+  }
+}
+
 declare module '@jovotech/output/dist/types/models/Card' {
   interface Card {
     header?: AplHeader;

--- a/output-alexa/src/utilities.ts
+++ b/output-alexa/src/utilities.ts
@@ -1,4 +1,4 @@
-import { Card, Carousel, Message } from '@jovotech/output';
+import { Card, Carousel, Message, RichAudio } from '@jovotech/output';
 import AplCardJson from './apl/Card.json';
 import AplCarouselJson from './apl/Carousel.json';
 import {
@@ -94,6 +94,25 @@ export function augmentModelPrototypes(): void {
       type: 'Alexa.Presentation.APL.RenderDocument',
       token: 'token',
       ...AplCarouselJson,
+    };
+  };
+
+  RichAudio.prototype.toApla = function () {
+    const AplaRichAudioJson = {
+      document: {
+        type: 'APLA',
+        version: '0.8',
+        mainTemplate: {
+          parameters: ['payload'],
+          item: this.toJson(),
+        }
+      },
+      datasources: {},
+    };
+    return {
+      type: 'Alexa.Presentation.APLA.RenderDocument',
+      token: 'token',
+      ...AplaRichAudioJson
     };
   };
 

--- a/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -50,8 +50,16 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       );
     }
 
+    const richAudio = output.platforms?.GoogleAssistant?.richAudio || output.richAudio;
+    if (richAudio) {
+      if (!response.prompt) {
+        response.prompt = {};
+      }
+      response.prompt.firstSimple = richAudio.toGoogleAssistantSsml?();
+    }
+
     const message = output.platforms?.GoogleAssistant?.message || output.message;
-    if (message) {
+    if (message && !richAudio) {
       if (!response.prompt) {
         response.prompt = {};
       }

--- a/output-googleassistant/src/index.ts
+++ b/output-googleassistant/src/index.ts
@@ -21,6 +21,12 @@ declare module '@jovotech/output/dist/types/models/Carousel' {
   }
 }
 
+declare module '@jovotech/output/dist/types/models/RichAudio' {
+  interface RichAudio {
+    toGoogleAssistantSsml?(): string;
+  }
+}
+
 declare module '@jovotech/output/dist/types/models/Message' {
   interface Message {
     toGoogleAssistantSimple?(): Simple;

--- a/output/src/models/OutputTemplateBase.ts
+++ b/output/src/models/OutputTemplateBase.ts
@@ -13,6 +13,7 @@ import { IsStringOrInstance } from '../decorators/validation/IsStringOrInstance'
 import { Card } from './Card';
 import { Carousel } from './Carousel';
 import { Message, MessageValue } from './Message';
+import { RichAudio } from './RichAudio';
 import { QuickReply, QuickReplyValue } from './QuickReply';
 
 export class OutputTemplateBase {
@@ -52,4 +53,10 @@ export class OutputTemplateBase {
   @ValidateNested()
   @Type(() => Carousel)
   carousel?: Carousel;
+
+  @IsOptional()
+  @IsInstance(RichAudio)
+  @ValidateNested()
+  @Type(() => RichAudio)
+  richAudio?: RichAudio;
 }

--- a/output/src/models/RichAudio.ts
+++ b/output/src/models/RichAudio.ts
@@ -1,0 +1,75 @@
+import { IsNotEmpty, IsString, IsUrl } from '..';
+
+export class Mixer {
+  type: 'Mixer',
+
+  @IsNotEmpty()
+  items: RichAudio[];
+
+  toJson() {
+    return {
+      type: this.type,
+      items: this.items.toJson(),
+    };
+  }
+};
+
+export class Sequencer {
+  type: 'Sequencer',
+
+  @IsNotEmpty()
+  items: RichAudio[];
+
+  toJson() {
+    return {
+      type: this.type,
+      items: this.items.toJson(),
+    };
+  }
+};
+
+export class Audio {
+  type: 'Audio',
+
+  @IsNotEmpty()
+  IsUrl()
+  source: string;
+
+  toJson() {
+    return {
+      type: this.type,
+      source: this.source,
+    };
+  }
+}
+
+export class Speech {
+  type: 'Speech',
+
+  @IsNotEmpty()
+  IsString()
+  content: string;
+
+  toJson() {
+    return {
+      type: this.type,
+      content: this.content,
+    };
+  }
+}
+
+export class Silence {
+  type: 'Silence',
+
+  @IsNotEmpty()
+  duration: number;
+
+  toJson() {
+    return {
+      type: this.type,
+      duration: this.duration,
+    };
+  }
+}
+
+export type RichAudio = Mixer | Sequencer | Audio | Speech | Silence;


### PR DESCRIPTION
For our Jovo v3 app, I wrote a [utility that converts APLA into Google Assistant style SSML](https://github.com/jovotech/jovo-output/compare/master...jtfell:feature/rich-audio?expand=1#diff-c40a50b48400532fc1dc5810c265463dbe8f97a52f9dfff6945b744d48f80ffeR17).

It's working really well to allow us to use a single representation for combined audio / text responses. We're using it something like this:

```ts
const richAudioRes: RichAudio = {
  type: 'Sequencer',
  items: [
    {
      type: "Audio",
      source: "https://assets.com/intro_sound.mp3"
    },
    {
      type: "Speech",
      content: "Welcome to our App"
     }
  ]
}

if (app.isAlexa()) {
  app.addAplDirective(genAlexaApla(richAudio));
}
if (app.isGoogle()) {
  app.message = genGoogleSsml(richAudio);
}
```

We want to migrate to v4 when its ready, and I've noticed that there is no equivalent for this yet.

What do you think of the approach I've sketched out in this PR? Its clearly not complete and I'm still figuring out the internals of Jovo, but I'd love some feedback on this idea and if it looks good then some direction how to get it ready for merging.

Cheers!
