### PR TITLE
🐛 Fix bug of `GoogleAssistantOutputTemplateConverterStrategy` when using dynamic entities

### DIFF
--- a/output-core/src/models/CoreResponse.ts
+++ b/output-core/src/models/CoreResponse.ts
@@ -9,7 +9,6 @@ import {
 } from '@jovotech/output';
 import { Context } from './Context';
 
-// TODO: Find better names for output and repromptOutputs!
 export class CoreResponse extends JovoResponse {
   @IsString()
   @IsNotEmpty()

--- a/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -106,7 +106,7 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       if (!response.session) {
         response.session = getEmptySession();
       }
-      response.session.typeOverrides = Object.keys(listen.entities).map((entityName) =>
+      response.session.typeOverrides = Object.keys(listen.entities.types).map((entityName) =>
         this.convertDynamicEntityToTypeOverride(
           entityName,
           ((listen.entities as DynamicEntities).types as DynamicEntityMap)[entityName],


### PR DESCRIPTION
Accidentally, the keys of the wrong object were iterated.