### PR TITLE
👔 Change logic to always wrap speech in SSML for Google Assistant

### DIFF
--- a/output-googleassistant/README.md
+++ b/output-googleassistant/README.md
@@ -20,7 +20,7 @@ This structured output is called [output template](https://v4.jovo.tech/docs/out
 }
 ```
 
-You can also add platform-specific output to an output template. [Learn more about Google Assistant-specific output below](#google-assistant-specific-output-elements).
+You can also add platform-specific output to an output template. [Learn more about Google Assistant-specific output below](#google-assistant-output-elements).
 
 ```typescript
 {
@@ -36,13 +36,20 @@ You can also add platform-specific output to an output template. [Learn more abo
 
 ## Generic Output Elements
 
-Generic output elements are in the root of the output template and work across platforms. [Learn more in the Jovo Output docs](https://v4.jovo.tech/docs/output-templates).
+Generic output elements are in the root of the output template and work across platforms. [Learn more in the Jovo output template docs](https://v4.jovo.tech/docs/output-templates).
 
-Below, you can find a list of generic output elements that work with Google Assistant.
+Below, you can find a list of generic output elements that work with Google Assistant:
 
-### Message
+- [`message`](#message)
+- [`reprompt`](#reprompt)
+- [`listen`](#listen)
+- [`quickReplies`](#quickreplies-suggestions) (called *suggestions* in Google Assistant)
+- [`card`](#card)
+- [`carousel`](#carousel) (called *collection* in Google Assistant)
 
-The `message` is what Google Assistant is saying (or displaying) to the user:
+### message
+
+The [generic `message` element](https://v4.jovo.tech/docs/output-templates#message) is what Google Assistant is saying (or displaying) to the user:
 
 ```typescript
 {
@@ -56,19 +63,21 @@ Under the hood, Jovo translates the `message` into a `firstSimple` response obje
 {
   "prompt": {
     "firstSimple": {
-      "speech": "Hello world!"
+      "speech": "<speak>Hello world!</speak>"
     }
   }
 }
 ```
+
+The resulting `speech` property gets automatically wrapped into SSML tags.
 
 It's also possible to add a `displayText` property:
 
 ```typescript
 {
   message: {
-    text: 'Speech hello world!',
-    displayText: 'Display hello world!'
+    text: 'Hello listener!',
+    displayText: 'Hello reader!'
   },
 }
 ```
@@ -79,14 +88,14 @@ This is then turned into the following response:
 {
   "prompt": {
     "firstSimple": {
-      "speech": "Speech hello world!",
-      "text": "Display hello world!"
+      "speech": "<speak>Hello listener!</speak>",
+      "text": "Hello reader!"
     }
   }
 }
 ```
 
-### Reprompt
+### reprompt
 
 If Google Assistant asks a question and the user does not respond after a few seconds, it will state a `reprompt` to ask again:
 
@@ -102,7 +111,7 @@ Under the hood, Jovo translates the `reprompt` into `NO_INPUT_1`, `NO_INPUT_2`, 
 
 **Note**: For Google Assistant to wait for a user to answer a question, the [listen property](#listen) needs to be added.
 
-### Listen
+### listen
 
 The `listen` property needs to be added to tell Google Assistant that it should keep the microphone open and wait for a user's response.
 
@@ -114,9 +123,9 @@ The `listen` property needs to be added to tell Google Assistant that it should 
 
 If `listen` is not set to `true`, Jovo transitions to the `actions.scene.END_CONVERSATION` under the hood.
 
-### Quick Replies (Suggestions)
+### quickReplies (Suggestions)
 
-On Google Assistant, quick replies are called suggestions. [You can learn more in the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts?hl=en#suggestions).
+The [generic `quickReplies` element](https://v4.jovo.tech/docs/output-templates#quick-replies) translates into a concept called suggestions on Google Assistant. [You can learn more in the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts?hl=en#suggestions).
 
 ```typescript
 {
@@ -125,23 +134,72 @@ On Google Assistant, quick replies are called suggestions. [You can learn more i
 }
 ```
 
-### Card
+Under the hood, Jovo translates `quickReplies` into the following:
 
-You can display a basic card ([see the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts-rich?hl=en)) by using the `card` property:
+```json
+{
+  "suggestions": [
+    {
+      "title": "Yes"
+    },
+    {
+      "title": "No"
+    }
+  ]
+}
+```
+
+If you define your `quickReplies` using objects instead of strings, the `text` property will be used for the resulting `title`:
+
+
+```typescript
+{
+  quickReplies: [
+    {
+      text: 'oh yeah', // this is used for 'title'
+      value: 'yes'
+    },
+    // ...
+  ]
+}
+```
+
+
+### card
+
+The [generic `card` element](https://v4.jovo.tech/docs/output-templates#card) can be used to display a basic card in Google Assistant. [Learn more about basic cards in the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts-rich?hl=en).
 
 ```typescript
 {
   // ...
   card: {
     title: 'Hello world!',
-    content: 'Welcome to this new app built with Jovo.'
+    subtitle: 'Some subtitle',
+    content: 'Welcome to this new app built with Jovo.',
+    imageUrl: 'https://...'
   },
 }
 ```
 
-### Carousel (Collection)
+Under the hood, this gets translated into the following object as part of the response to Google Assistant:
 
-You can display a collection ([see the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts-selection?hl=en#collection)) by using the `carousel` property:
+```json
+{
+  "card": {
+    "title": "Hello world!",
+    "subtitle": "Some subtitle",
+    "text": "Welcome to this new app built with Jovo.", // Taken from 'content'
+    "image": {
+      "alt": "Hello world!", // Taken from 'title'
+      "url": "https://...",
+    }
+  }
+}
+```
+
+### carousel (Collection)
+
+A [generic `carousel` element](https://v4.jovo.tech/docs/output-templates#carousel) is a horizontally scrollable set of [`card`](#card) items. In Google Assistant, this is called a *collection*. [Learn more in the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts-selection?hl=en#collection).
 
 ```typescript
 {
@@ -187,9 +245,9 @@ It includes the following properties:
 * `title` (optional): A string that gets displayed at the top.
 
 
-## Google Assistant-specific Output Elements
+## Google Assistant Output Elements
 
-It is possible to add platform-specific output elements to an output template. [Learn more in the Jovo output documentation](https://v4.jovo.tech/docs/output-templates#platform-specific-output-elements).
+It is possible to add platform-specific output elements to an output template. [Learn more in the Jovo output template documentation](https://v4.jovo.tech/docs/output-templates#platform-specific-output-elements).
 
 For Google Assistant, you can add output elements inside an `googleAssistant` object:
 
@@ -204,7 +262,7 @@ For Google Assistant, you can add output elements inside an `googleAssistant` ob
 }
 ```
 
-### Native Response
+### nativeResponse
 
 The [`nativeResponse` property](https://v4.jovo.tech/docs/output-templates#native-response) allows you to add native elements exactly how they would be added to the Google Assistant JSON response.
 

--- a/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -10,6 +10,7 @@ import {
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
   SingleResponseOutputTemplateConverterStrategy,
+  toSSML,
 } from '@jovotech/output';
 import {
   COLLECTION_MAX_SIZE,
@@ -261,9 +262,9 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
 
   convertMessageToSimple(message: MessageValue): Simple {
     return typeof message === 'string'
-      ? { speech: message }
+      ? { speech: toSSML(message) }
       : message.toGoogleAssistantSimple?.() || {
-          speech: message.text,
+          speech: toSSML(message.text),
           text: message.displayText,
         };
   }

--- a/output-googleassistant/src/utilities.ts
+++ b/output-googleassistant/src/utilities.ts
@@ -1,4 +1,4 @@
-import { Card, Carousel, Message, QuickReply } from '@jovotech/output';
+import { Card, Carousel, Message, QuickReply, toSSML } from '@jovotech/output';
 import {
   Card as GoogleAssistantCard,
   Collection,
@@ -59,7 +59,7 @@ export function augmentModelPrototypes(): void {
 
   Message.prototype.toGoogleAssistantSimple = function () {
     const simple: Simple = {
-      speech: this.text,
+      speech: toSSML(this.text),
     };
     if (this.displayText) {
       simple.text = this.displayText;


### PR DESCRIPTION
The `speech` should always be SSML.