### PR TITLE
♻️💥 Refactor `Message` 

### DIFF
--- a/docs/output-templates.md
+++ b/docs/output-templates.md
@@ -60,8 +60,8 @@ A `message` can either be a `string` or have the following properties:
 ```typescript
 {
   message: {
-    speech: 'Hello world!', // Default message
-    text: 'Hello screen!', // For voice platforms that support display text
+    speech: 'Hello world!', // For voice platforms
+    text: 'Hello screen!', // For chat platforms and voice platforms that support display text
   }
 }
 ```

--- a/docs/output-templates.md
+++ b/docs/output-templates.md
@@ -60,8 +60,8 @@ A `message` can either be a `string` or have the following properties:
 ```typescript
 {
   message: {
-    text: 'Hello world!', // Default message
-    displayText: 'Hello screen!', // For voice platforms that support display text
+    speech: 'Hello world!', // Default message
+    text: 'Hello screen!', // For voice platforms that support display text
   }
 }
 ```
@@ -77,7 +77,7 @@ The `reprompt` is typically only relevant for voice interfaces. It represents th
 }
 ```
 
-A `reprompt` can have the same values (`text`, `displayText`) as a [`message`](#message).
+A `reprompt` can have the same values (`speech`, `text`) as a [`message`](#message).
 
 
 ### Card
@@ -307,7 +307,7 @@ Platforms that support multiple responses will display the example above in 2 ch
 }
 ```
 
-If the [`message`](#message) is an object for one of the output objects, the other `message` strings are treated as if the spoken `text` and `displayText` are the same. Here is an example:
+If the [`message`](#message) is an object for one of the output objects, the other `message` strings are treated as if the spoken `speech` and `text` are the same. Here is an example:
 
 ```typescript
 // Before merging
@@ -317,8 +317,8 @@ If the [`message`](#message) is an object for one of the output objects, the oth
   },
   {
     message: {
-      text: 'This is spoken text.',
-      displayText: 'This is display text.'
+      speech: 'This is spoken text.',
+      text: 'This is display text.'
     },
   }
 ]
@@ -326,8 +326,8 @@ If the [`message`](#message) is an object for one of the output objects, the oth
 // After merging
 {
   message: {
-    text: 'Hello world! This is spoken text.',
-    displayText: 'Hello world! This is display text.'
+    speech: 'Hello world! This is spoken text.',
+    text: 'Hello world! This is display text.'
   },
 }
 ```

--- a/output-alexa/README.md
+++ b/output-alexa/README.md
@@ -60,6 +60,17 @@ Under the hood, Jovo translates the `message` into an `outputSpeech` object ([se
 }
 ```
 
+If the `message` is an object that contains `speech` and `text`, the `speech` property will be used for Alexa:
+
+```typescript
+{
+  message: {
+    speech: 'Hello world!', // Used by Alexa
+    text: 'Hello screen!', // Used by chat platforms or other voice platforms that support display text
+  }
+}
+```
+
 ### Reprompt
 
 If Alexa asks a question and the user does not respond after a few seconds, it will state a `reprompt` to ask again:

--- a/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
+++ b/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
@@ -9,7 +9,6 @@ import {
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
   SingleResponseOutputTemplateConverterStrategy,
-  toSSML,
 } from '@jovotech/output';
 import { ALEXA_STRING_MAX_LENGTH, SLOT_TYPE_VALUES_MAX_SIZE, SSML_OFFSET } from './constants';
 import {
@@ -19,9 +18,9 @@ import {
   Directive,
   DynamicEntitiesUpdateBehavior,
   OutputSpeech,
-  OutputSpeechType,
   SlotType,
 } from './models';
+import { convertMessageToOutputSpeech } from './utilities';
 
 export interface AlexaOutputTemplateConverterStrategyConfig
   extends OutputTemplateConverterStrategyConfig {
@@ -115,13 +114,13 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
 
     const message = output.message;
     if (message) {
-      response.response.outputSpeech = this.convertMessageToOutputSpeech(message);
+      response.response.outputSpeech = convertMessageToOutputSpeech(message);
     }
 
     const reprompt = output.reprompt;
     if (reprompt) {
       response.response.reprompt = {
-        outputSpeech: this.convertMessageToOutputSpeech(reprompt),
+        outputSpeech: convertMessageToOutputSpeech(reprompt),
       };
     }
 
@@ -217,18 +216,6 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
     }
 
     return output;
-  }
-
-  convertMessageToOutputSpeech(message: MessageValue): OutputSpeech {
-    return typeof message === 'string'
-      ? {
-          type: OutputSpeechType.Ssml,
-          ssml: toSSML(message),
-        }
-      : message.toAlexaOutputSpeech?.() || {
-          type: OutputSpeechType.Ssml,
-          ssml: toSSML(message.speech),
-        };
   }
 
   private convertDynamicEntityToSlotType(name: string, entity: DynamicEntity): SlotType {

--- a/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
+++ b/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
@@ -227,7 +227,7 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
         }
       : message.toAlexaOutputSpeech?.() || {
           type: OutputSpeechType.Ssml,
-          ssml: toSSML(message.text),
+          ssml: toSSML(message.speech),
         };
   }
 

--- a/output-alexa/src/index.ts
+++ b/output-alexa/src/index.ts
@@ -31,7 +31,7 @@ declare module '@jovotech/output/dist/types/models/Carousel' {
 
 declare module '@jovotech/output/dist/types/models/Message' {
   interface Message {
-    toAlexaOutputSpeech?(): OutputSpeech<OutputSpeechType.Ssml>;
+    toAlexaOutputSpeech?(): OutputSpeech;
   }
 }
 
@@ -58,4 +58,4 @@ export * from './constants';
 
 export * from './AlexaOutputTemplateConverterStrategy';
 
-export { validateAlexaString } from './utilities';
+export { validateAlexaString, convertMessageToOutputSpeech } from './utilities';

--- a/output-alexa/src/models/common/OutputSpeech.ts
+++ b/output-alexa/src/models/common/OutputSpeech.ts
@@ -39,8 +39,9 @@ export class OutputSpeech<TYPE extends OutputSpeechTypeLike = OutputSpeechTypeLi
   playBehavior?: PlayBehaviorLike;
 
   toMessage?(): MessageValue {
-    return this.type === OutputSpeechType.Plain
-      ? ((this.text || '') as string)
-      : removeSSMLSpeakTags((this.ssml || '') as string);
+    const value = (this.type === OutputSpeechType.Plain ? this.text : this.ssml) as
+      | MessageValue
+      | undefined;
+    return value || '';
   }
 }

--- a/output-alexa/src/models/common/OutputSpeech.ts
+++ b/output-alexa/src/models/common/OutputSpeech.ts
@@ -39,9 +39,16 @@ export class OutputSpeech<TYPE extends OutputSpeechTypeLike = OutputSpeechTypeLi
   playBehavior?: PlayBehaviorLike;
 
   toMessage?(): MessageValue {
-    const value = (this.type === OutputSpeechType.Plain ? this.text : this.ssml) as
-      | MessageValue
-      | undefined;
-    return value || '';
+    if (this.type === OutputSpeechType.Ssml && this.ssml) {
+      return {
+        speech: this.ssml as string,
+      };
+    }
+    if (this.type === OutputSpeechType.Plain && this.text) {
+      return {
+        text: this.text as string,
+      };
+    }
+    return '';
   }
 }

--- a/output-alexa/src/utilities.ts
+++ b/output-alexa/src/utilities.ts
@@ -101,7 +101,7 @@ export function augmentModelPrototypes(): void {
   Message.prototype.toAlexaOutputSpeech = function () {
     return {
       type: OutputSpeechType.Ssml,
-      ssml: toSSML(this.text),
+      ssml: toSSML(this.speech),
     };
   };
 }

--- a/output-dialogflow/src/DialogflowOutputTemplateConverterStrategy.ts
+++ b/output-dialogflow/src/DialogflowOutputTemplateConverterStrategy.ts
@@ -8,7 +8,6 @@ import {
   OutputTemplate,
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
-  removeSSML,
   SingleResponseOutputTemplateConverterStrategy,
 } from '@jovotech/output';
 import { QUICK_REPLIES_MAX_SIZE, QUICK_REPLY_MAX_LENGTH, TEXT_MAX_LENGTH } from './constants';
@@ -83,7 +82,7 @@ export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOut
       }
       response.fulfillment_messages.push({
         message: {
-          text: this.convertMessageToText(message),
+          text: convertMessageToText(message),
         },
       });
     }
@@ -166,14 +165,6 @@ export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOut
     return output;
   }
 
-  convertMessageToText(message: MessageValue): Text {
-    return typeof message === 'string'
-      ? { text: [removeSSML(message)] }
-      : message.toDialogflowText?.() || {
-          text: [removeSSML(message.text || message.speech)],
-        };
-  }
-
   convertQuickReplyToDialogflowQuickReply(quickReply: QuickReplyValue): string {
     return typeof quickReply === 'string'
       ? quickReply
@@ -208,4 +199,7 @@ export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOut
       })),
     };
   }
+}
+function convertMessageToText(message: MessageValue): Text | undefined {
+  throw new Error('Function not implemented.');
 }

--- a/output-dialogflow/src/DialogflowOutputTemplateConverterStrategy.ts
+++ b/output-dialogflow/src/DialogflowOutputTemplateConverterStrategy.ts
@@ -8,6 +8,7 @@ import {
   OutputTemplate,
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
+  removeSSML,
   SingleResponseOutputTemplateConverterStrategy,
 } from '@jovotech/output';
 import { QUICK_REPLIES_MAX_SIZE, QUICK_REPLY_MAX_LENGTH, TEXT_MAX_LENGTH } from './constants';
@@ -167,9 +168,9 @@ export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOut
 
   convertMessageToText(message: MessageValue): Text {
     return typeof message === 'string'
-      ? { text: [message] }
+      ? { text: [removeSSML(message)] }
       : message.toDialogflowText?.() || {
-          text: [message.displayText || message.text],
+          text: [removeSSML(message.text || message.speech)],
         };
   }
 

--- a/output-dialogflow/src/index.ts
+++ b/output-dialogflow/src/index.ts
@@ -42,3 +42,5 @@ export * from './DialogflowOutputTemplateConverterStrategy';
 
 export * from './models';
 export * from './constants';
+
+export { convertMessageToDialogflowText } from './utilities';

--- a/output-dialogflow/src/models/message/Text.ts
+++ b/output-dialogflow/src/models/message/Text.ts
@@ -1,4 +1,11 @@
-import { ArrayMaxSize, IsArray, IsNotEmpty, IsOptional, IsString, Message } from '@jovotech/output';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MessageValue,
+} from '@jovotech/output';
 import { TEXT_MAX_LENGTH } from '../../constants';
 
 export class Text {
@@ -9,9 +16,7 @@ export class Text {
   @IsNotEmpty({ each: true })
   text?: string[];
 
-  toMessage?(): Message {
-    return {
-      text: this.text?.[0] || '',
-    };
+  toMessage?(): MessageValue {
+    return this.text?.[0] || '';
   }
 }

--- a/output-dialogflow/src/utilities.ts
+++ b/output-dialogflow/src/utilities.ts
@@ -1,5 +1,23 @@
-import { Card, Message, QuickReply, removeSSML } from '@jovotech/output';
-import { Card as DialogflowCard } from './models';
+import {
+  Card,
+  Message,
+  MessageValue,
+  QuickReply,
+  removeSSML,
+  SpeechMessage,
+  TextMessage,
+} from '@jovotech/output';
+import { Card as DialogflowCard, Text } from './models';
+
+export function convertMessageToDialogflowText(message: MessageValue): Text {
+  return {
+    text: [
+      removeSSML(
+        typeof message === 'string' ? message : message.text || (message.speech as string),
+      ),
+    ],
+  };
+}
 
 export function augmentModelPrototypes(): void {
   Card.prototype.toDialogflowCard = function () {
@@ -17,7 +35,7 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toDialogflowText = function () {
-    return { text: [removeSSML(this.text || this.speech)] };
+    return convertMessageToDialogflowText(this as TextMessage | SpeechMessage);
   };
 
   QuickReply.prototype.toDialogflowQuickReply = function () {

--- a/output-dialogflow/src/utilities.ts
+++ b/output-dialogflow/src/utilities.ts
@@ -1,4 +1,4 @@
-import { Card, Message, QuickReply } from '@jovotech/output';
+import { Card, Message, QuickReply, removeSSML } from '@jovotech/output';
 import { Card as DialogflowCard } from './models';
 
 export function augmentModelPrototypes(): void {
@@ -17,7 +17,7 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toDialogflowText = function () {
-    return { text: [this.displayText || this.text] };
+    return { text: [removeSSML(this.text || this.speech)] };
   };
 
   QuickReply.prototype.toDialogflowQuickReply = function () {

--- a/output-facebookmessenger/README.md
+++ b/output-facebookmessenger/README.md
@@ -53,13 +53,13 @@ The [generic `message` element](https://v4.jovo.tech/docs/output-templates#messa
 }
 ```
 
-It is also possible to use `message` as an object which contains both a `text` (the *spoken* text on platforms like Alexa) and a `displayText` (*written* text to be displayed in chat bubbles) field. In this case, Facebook Messenger uses the `displayText` element.
+It is also possible to use `message` as an object which contains both a `speech` (the *spoken* text on platforms like Alexa) and a `text` (*written* text to be displayed in chat bubbles) field. In this case, Facebook Messenger uses the `text` element.
 
 ```typescript
 {
   message: {
-    text: 'Hello listener!',
-    displayText: 'Hello reader!'
+    speech: 'Hello listener!',
+    text: 'Hello reader!'
   }
 }
 ```

--- a/output-facebookmessenger/src/FacebookMessengerOutputTemplateConverterStrategy.ts
+++ b/output-facebookmessenger/src/FacebookMessengerOutputTemplateConverterStrategy.ts
@@ -6,7 +6,6 @@ import {
   OutputTemplateConverterStrategyConfig,
   QuickReply,
   QuickReplyValue,
-  removeSSML,
 } from '@jovotech/output';
 import {
   GENERIC_TEMPLATE_MAX_SIZE,
@@ -24,6 +23,7 @@ import {
   QuickReplyContentType,
   TemplateType,
 } from './models';
+import { convertMessageToFacebookMessengerMessage } from './utilities';
 
 export class FacebookMessengerOutputTemplateConverterStrategy extends MultipleResponsesOutputTemplateConverterStrategy<
   FacebookMessengerResponse,
@@ -98,7 +98,7 @@ export class FacebookMessengerOutputTemplateConverterStrategy extends MultipleRe
 
     const message = output.message;
     if (message) {
-      addMessageToResponses(this.convertMessageToFacebookMessengerMessage(message));
+      addMessageToResponses(convertMessageToFacebookMessengerMessage(message));
     }
 
     const card = output.card;
@@ -172,15 +172,6 @@ export class FacebookMessengerOutputTemplateConverterStrategy extends MultipleRe
     }
 
     return output;
-  }
-
-  convertMessageToFacebookMessengerMessage(message: MessageValue): FacebookMessengerMessage {
-    return typeof message === 'string'
-      ? { text: removeSSML(message) }
-      : message.toFacebookMessengerMessage?.() || {
-          text: removeSSML(message.text || message.speech),
-          quick_replies: [],
-        };
   }
 
   convertQuickReplyToFacebookMessengerQuickReply(

--- a/output-facebookmessenger/src/FacebookMessengerOutputTemplateConverterStrategy.ts
+++ b/output-facebookmessenger/src/FacebookMessengerOutputTemplateConverterStrategy.ts
@@ -178,7 +178,7 @@ export class FacebookMessengerOutputTemplateConverterStrategy extends MultipleRe
     return typeof message === 'string'
       ? { text: removeSSML(message) }
       : message.toFacebookMessengerMessage?.() || {
-          text: removeSSML(message.displayText || message.text),
+          text: removeSSML(message.text || message.speech),
           quick_replies: [],
         };
   }

--- a/output-facebookmessenger/src/index.ts
+++ b/output-facebookmessenger/src/index.ts
@@ -60,3 +60,4 @@ export * from './models';
 export * from './constants';
 
 export * from './FacebookMessengerOutputTemplateConverterStrategy';
+export { convertMessageToFacebookMessengerMessage } from './utilities';

--- a/output-facebookmessenger/src/models/message/Message.ts
+++ b/output-facebookmessenger/src/models/message/Message.ts
@@ -11,10 +11,7 @@ import {
 } from '@jovotech/output';
 import { MESSAGE_TEXT_MAX_LENGTH, PAYLOAD_MAX_LENGTH } from '../../constants';
 import { TransformQuickReply } from '../../decorators/transformation/TransformQuickReply';
-import { UserEmailQuickReply } from '../quick-reply/UserEmailQuickReply';
-import { UserPhoneNumberQuickReply } from '../quick-reply/UserPhoneNumberQuickReply';
-import { QuickReply, QuickReplyContentType } from '../quick-reply/QuickReply';
-import { TextQuickReply } from '../quick-reply/TextQuickReply';
+import { QuickReply } from '../quick-reply/QuickReply';
 import { MessageAttachment } from './MessageAttachment';
 
 export class Message {

--- a/output-facebookmessenger/src/utilities.ts
+++ b/output-facebookmessenger/src/utilities.ts
@@ -1,4 +1,13 @@
-import { Card, Carousel, Message, QuickReply, removeSSML } from '@jovotech/output';
+import {
+  Card,
+  Carousel,
+  Message,
+  MessageValue,
+  QuickReply,
+  removeSSML,
+  SpeechMessage,
+  TextMessage,
+} from '@jovotech/output';
 import { GENERIC_TEMPLATE_MAX_SIZE } from './constants';
 import {
   GenericTemplateElement,
@@ -7,6 +16,16 @@ import {
   QuickReplyContentType,
   TemplateType,
 } from './models';
+
+export function convertMessageToFacebookMessengerMessage(
+  message: MessageValue,
+): FacebookMessengerMessage {
+  return {
+    text: removeSSML(
+      typeof message === 'string' ? message : message.text || (message.speech as string),
+    ),
+  };
+}
 
 export function augmentModelPrototypes(): void {
   Card.prototype.toFacebookMessengerGenericTemplateElement = function () {
@@ -63,10 +82,7 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toFacebookMessengerMessage = function () {
-    const message: FacebookMessengerMessage = {
-      text: removeSSML(this.text || this.speech),
-    };
-    return message;
+    return convertMessageToFacebookMessengerMessage(this as SpeechMessage | TextMessage);
   };
 
   QuickReply.prototype.toFacebookQuickReply = function () {

--- a/output-facebookmessenger/src/utilities.ts
+++ b/output-facebookmessenger/src/utilities.ts
@@ -64,7 +64,7 @@ export function augmentModelPrototypes(): void {
 
   Message.prototype.toFacebookMessengerMessage = function () {
     const message: FacebookMessengerMessage = {
-      text: removeSSML(this.displayText || this.text),
+      text: removeSSML(this.text || this.speech),
     };
     return message;
   };

--- a/output-googleassistant/README.md
+++ b/output-googleassistant/README.md
@@ -71,7 +71,7 @@ Under the hood, Jovo translates the `message` into a `firstSimple` response obje
 
 The resulting `speech` property gets automatically wrapped into SSML tags.
 
-It's also possible to add a `text` property:
+It's also possible to turn `message` into an object with a `speech` and a `text` property:
 
 ```typescript
 {

--- a/output-googleassistant/README.md
+++ b/output-googleassistant/README.md
@@ -71,13 +71,13 @@ Under the hood, Jovo translates the `message` into a `firstSimple` response obje
 
 The resulting `speech` property gets automatically wrapped into SSML tags.
 
-It's also possible to add a `displayText` property:
+It's also possible to add a `text` property:
 
 ```typescript
 {
   message: {
-    text: 'Hello listener!',
-    displayText: 'Hello reader!'
+    speech: 'Hello listener!',
+    text: 'Hello reader!'
   },
 }
 ```

--- a/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -9,9 +9,7 @@ import {
   OutputTemplate,
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
-  removeSSML,
   SingleResponseOutputTemplateConverterStrategy,
-  toSSML,
 } from '@jovotech/output';
 import {
   COLLECTION_MAX_SIZE,
@@ -122,7 +120,7 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       if (!response.prompt) {
         response.prompt = {};
       }
-      response.prompt.firstSimple = this.convertMessageToSimple(message);
+      response.prompt.firstSimple = convertMessageToSimple(message);
     }
 
     const reprompt = output.reprompt;
@@ -130,8 +128,7 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       if (!response.session) {
         response.session = getEmptySession();
       }
-      const text =
-        typeof reprompt === 'string' ? reprompt : reprompt.text || reprompt.speech;
+      const text = typeof reprompt === 'string' ? reprompt : reprompt.text || reprompt.speech;
       response.session.params._GOOGLE_ASSISTANT_REPROMPTS_ = {
         NO_INPUT_1: text,
         NO_INPUT_2: text,
@@ -262,15 +259,6 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
     return output;
   }
 
-  convertMessageToSimple(message: MessageValue): Simple {
-    return typeof message === 'string'
-      ? { speech: toSSML(message), text: removeSSML(message) }
-      : message.toGoogleAssistantSimple?.() || {
-          speech: toSSML(message.speech),
-          text: removeSSML(message.text || message.speech),
-        };
-  }
-
   convertQuickReplyToSuggestion(quickReply: QuickReplyValue): Suggestion {
     return typeof quickReply === 'string'
       ? { title: quickReply }
@@ -305,4 +293,7 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       })),
     };
   }
+}
+function convertMessageToSimple(message: MessageValue): Simple | undefined {
+  throw new Error('Function not implemented.');
 }

--- a/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -130,7 +130,8 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       if (!response.session) {
         response.session = getEmptySession();
       }
-      const text = typeof reprompt === 'string' ? reprompt : reprompt.displayText || reprompt.text;
+      const text =
+        typeof reprompt === 'string' ? reprompt : reprompt.text || reprompt.speech;
       response.session.params._GOOGLE_ASSISTANT_REPROMPTS_ = {
         NO_INPUT_1: text,
         NO_INPUT_2: text,
@@ -265,8 +266,8 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
     return typeof message === 'string'
       ? { speech: toSSML(message), text: removeSSML(message) }
       : message.toGoogleAssistantSimple?.() || {
-          speech: toSSML(message.text),
-          text: removeSSML(message.displayText || message.text),
+          speech: toSSML(message.speech),
+          text: removeSSML(message.text || message.speech),
         };
   }
 

--- a/output-googleassistant/src/index.ts
+++ b/output-googleassistant/src/index.ts
@@ -49,3 +49,4 @@ export * from './models';
 export * from './constants';
 
 export * from './GoogleAssistantOutputTemplateConverterStrategy';
+export { convertMessageToGoogleAssistantSimple } from './utilities';

--- a/output-googleassistant/src/models/Prompt.ts
+++ b/output-googleassistant/src/models/Prompt.ts
@@ -52,8 +52,8 @@ export class Simple {
     const speech = this.speech || '';
     return this.text
       ? {
-          displayText: this.text,
-          text: speech,
+          text: this.text,
+          speech,
         }
       : speech;
   }

--- a/output-googleassistant/src/models/Prompt.ts
+++ b/output-googleassistant/src/models/Prompt.ts
@@ -9,6 +9,8 @@ import {
   IsUrl,
   MaxLength,
   MessageValue,
+  SpeechMessage,
+  TextMessage,
   Type,
   ValidateNested,
 } from '@jovotech/output';
@@ -49,13 +51,14 @@ export class Simple {
   text?: string;
 
   toMessage?(): MessageValue {
-    const speech = this.speech || '';
-    return this.text
-      ? {
-          text: this.text,
-          speech,
-        }
-      : speech;
+    const message = {} as SpeechMessage | TextMessage;
+    if (this.text) {
+      message.text = this.text;
+    }
+    if (this.speech) {
+      message.speech = this.speech;
+    }
+    return message;
   }
 }
 

--- a/output-googleassistant/src/utilities.ts
+++ b/output-googleassistant/src/utilities.ts
@@ -59,8 +59,8 @@ export function augmentModelPrototypes(): void {
 
   Message.prototype.toGoogleAssistantSimple = function () {
     return {
-      speech: toSSML(this.text),
-      text: removeSSML(this.displayText || this.text),
+      speech: toSSML(this.speech),
+      text: removeSSML(this.text || this.speech),
     };
   };
 

--- a/output-googleassistant/src/utilities.ts
+++ b/output-googleassistant/src/utilities.ts
@@ -1,4 +1,14 @@
-import { Card, Carousel, Message, QuickReply, removeSSML, toSSML } from '@jovotech/output';
+import {
+  Card,
+  Carousel,
+  Message,
+  MessageValue,
+  QuickReply,
+  removeSSML,
+  SpeechMessage,
+  TextMessage,
+  toSSML,
+} from '@jovotech/output';
 import {
   Card as GoogleAssistantCard,
   Collection,
@@ -6,6 +16,20 @@ import {
   TypeOverride,
   TypeOverrideMode,
 } from './models';
+
+export function convertMessageToGoogleAssistantSimple(message: MessageValue): Simple {
+  if (typeof message === 'string') {
+    return {
+      speech: toSSML(message),
+      text: removeSSML(message),
+    };
+  }
+
+  return {
+    speech: toSSML(message.speech || (message.text as string)),
+    text: removeSSML(message.text || (message.speech as string)),
+  };
+}
 
 export function augmentModelPrototypes(): void {
   Card.prototype.toGoogleAssistantCard = function () {
@@ -58,10 +82,7 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toGoogleAssistantSimple = function () {
-    return {
-      speech: toSSML(this.speech),
-      text: removeSSML(this.text || this.speech),
-    };
+    return convertMessageToGoogleAssistantSimple(this as SpeechMessage | TextMessage);
   };
 
   QuickReply.prototype.toGoogleAssistantSuggestion = function () {

--- a/output-googleassistantlegacy/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistantlegacy/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -2,13 +2,10 @@ import {
   Card,
   Carousel,
   mergeInstances,
-  MessageValue,
   OutputTemplate,
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
-  removeSSML,
   SingleResponseOutputTemplateConverterStrategy,
-  toSSML,
 } from '@jovotech/output';
 import {
   BASIC_CARD_TEXT_MAX_LENGTH,
@@ -16,11 +13,11 @@ import {
   CAROUSEL_MAX_SIZE,
   CAROUSEL_MIN_SIZE,
   GoogleAssistantResponse,
-  SimpleResponse,
   Suggestion,
   SUGGESTION_TITLE_MAX_LENGTH,
   SUGGESTIONS_MAX_SIZE,
 } from './index';
+import { convertMessageToGoogleAssistantSimpleResponse } from './utilities';
 
 // TODO: CHECK: Theoretically, this platform can have multiple messages but we have never used this feature so far.
 // In case we want to support that, the implementation of this strategy has to be adjusted.
@@ -92,13 +89,13 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
     const message = output.message;
     if (message) {
       response.richResponse.items.push({
-        simpleResponse: this.convertMessageToSimpleResponse(message),
+        simpleResponse: convertMessageToGoogleAssistantSimpleResponse(message),
       });
     }
 
     const reprompt = output.reprompt;
     if (reprompt) {
-      response.noInputPrompts = [this.convertMessageToSimpleResponse(reprompt)];
+      response.noInputPrompts = [convertMessageToGoogleAssistantSimpleResponse(reprompt)];
     }
 
     const quickReplies = output.quickReplies;
@@ -167,15 +164,6 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
     }
 
     return output;
-  }
-
-  convertMessageToSimpleResponse(message: MessageValue): SimpleResponse {
-    return typeof message === 'string'
-      ? { ssml: toSSML(message), displayText: removeSSML(message) }
-      : message.toGoogleAssistantSimpleResponse?.() || {
-          ssml: toSSML(message.speech),
-          displayText: removeSSML(message.text || message.speech),
-        };
   }
 
   convertQuickReplyToSuggestion(quickReply: QuickReplyValue): Suggestion {

--- a/output-googleassistantlegacy/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistantlegacy/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -6,6 +6,7 @@ import {
   OutputTemplate,
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
+  removeSSML,
   SingleResponseOutputTemplateConverterStrategy,
   toSSML,
 } from '@jovotech/output';
@@ -170,10 +171,10 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
 
   convertMessageToSimpleResponse(message: MessageValue): SimpleResponse {
     return typeof message === 'string'
-      ? { ssml: toSSML(message) }
+      ? { ssml: toSSML(message), displayText: removeSSML(message) }
       : message.toGoogleAssistantSimpleResponse?.() || {
-          ssml: toSSML(message.text),
-          displayText: message.displayText,
+          ssml: toSSML(message.speech),
+          displayText: removeSSML(message.text || message.speech),
         };
   }
 

--- a/output-googleassistantlegacy/src/index.ts
+++ b/output-googleassistantlegacy/src/index.ts
@@ -56,3 +56,4 @@ export * from './models';
 export * from './constants';
 
 export * from './GoogleAssistantOutputTemplateConverterStrategy';
+export { convertMessageToGoogleAssistantSimpleResponse } from './utilities';

--- a/output-googleassistantlegacy/src/models/simple-response/SimpleResponse.ts
+++ b/output-googleassistantlegacy/src/models/simple-response/SimpleResponse.ts
@@ -23,12 +23,12 @@ export class SimpleResponse {
   displayText?: string;
 
   toMessage?(): MessageValue {
-    const text = removeSSMLSpeakTags(this.ssml || this.textToSpeech || '');
+    const speech = this.ssml || this.textToSpeech || '';
     return this.displayText
       ? {
-          displayText: this.displayText,
-          text,
+          text: this.displayText,
+          speech,
         }
-      : text;
+      : speech;
   }
 }

--- a/output-googleassistantlegacy/src/models/simple-response/SimpleResponse.ts
+++ b/output-googleassistantlegacy/src/models/simple-response/SimpleResponse.ts
@@ -5,6 +5,8 @@ import {
   MaxLength,
   MessageValue,
   removeSSMLSpeakTags,
+  SpeechMessage,
+  TextMessage,
 } from '@jovotech/output';
 import { SIMPLE_RESPONSE_DISPLAY_TEXT_MAX_LENGTH } from '../../constants';
 import { IsValidSimpleResponseString } from '../../decorators/validation/IsValidSimpleResponseString';
@@ -23,12 +25,13 @@ export class SimpleResponse {
   displayText?: string;
 
   toMessage?(): MessageValue {
-    const speech = this.ssml || this.textToSpeech || '';
-    return this.displayText
-      ? {
-          text: this.displayText,
-          speech,
-        }
-      : speech;
+    const message = {} as SpeechMessage | TextMessage;
+    if (this.displayText) {
+      message.text = this.displayText;
+    }
+    if (this.ssml || this.textToSpeech) {
+      message.speech = this.ssml || this.textToSpeech;
+    }
+    return message;
   }
 }

--- a/output-googleassistantlegacy/src/utilities.ts
+++ b/output-googleassistantlegacy/src/utilities.ts
@@ -1,4 +1,4 @@
-import { Card, Carousel, Message, QuickReply, toSSML } from '@jovotech/output';
+import { Card, Carousel, Message, QuickReply, removeSSML, toSSML } from '@jovotech/output';
 import { BasicCard, CollectionItem, SimpleResponse } from './models';
 
 export function augmentModelPrototypes(): void {
@@ -46,13 +46,10 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toGoogleAssistantSimpleResponse = function () {
-    const simpleResponse: SimpleResponse = {
-      ssml: toSSML(this.text),
+    return {
+      ssml: toSSML(this.speech),
+      displayText: removeSSML(this.text || this.speech),
     };
-    if (this.displayText) {
-      simpleResponse.displayText = this.displayText;
-    }
-    return simpleResponse;
   };
 
   QuickReply.prototype.toGoogleAssistantSuggestion = function () {

--- a/output-googleassistantlegacy/src/utilities.ts
+++ b/output-googleassistantlegacy/src/utilities.ts
@@ -1,5 +1,30 @@
-import { Card, Carousel, Message, QuickReply, removeSSML, toSSML } from '@jovotech/output';
+import {
+  Card,
+  Carousel,
+  Message,
+  MessageValue,
+  QuickReply,
+  removeSSML,
+  SpeechMessage,
+  TextMessage,
+  toSSML,
+} from '@jovotech/output';
 import { BasicCard, CollectionItem, SimpleResponse } from './models';
+
+export function convertMessageToGoogleAssistantSimpleResponse(
+  message: MessageValue,
+): SimpleResponse {
+  if (typeof message === 'string') {
+    return {
+      ssml: toSSML(message),
+      displayText: removeSSML(message),
+    };
+  }
+  return {
+    ssml: toSSML(message.speech || (message.text as string)),
+    displayText: removeSSML(message.text || (message.speech as string)),
+  };
+}
 
 export function augmentModelPrototypes(): void {
   Card.prototype.toGoogleAssistantBasicCard = function () {
@@ -46,10 +71,7 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toGoogleAssistantSimpleResponse = function () {
-    return {
-      ssml: toSSML(this.speech),
-      displayText: removeSSML(this.text || this.speech),
-    };
+    return convertMessageToGoogleAssistantSimpleResponse(this as SpeechMessage | TextMessage);
   };
 
   QuickReply.prototype.toGoogleAssistantSuggestion = function () {

--- a/output-googleassistantlegacy/test/strategy.test.ts
+++ b/output-googleassistantlegacy/test/strategy.test.ts
@@ -696,7 +696,7 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: toSSML('foo'),
+        message: { speech: toSSML('foo') },
         listen: true,
       },
     );
@@ -728,7 +728,7 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: toSSML('foo'),
+        message: { speech: toSSML('foo') },
         carousel: {
           items: [
             { key: 'one', title: 'one' },
@@ -754,8 +754,8 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: toSSML('foo'),
-        reprompt: toSSML('foo'),
+        message: { speech: toSSML('foo') },
+        reprompt: { speech: toSSML('foo') },
       },
     );
   });
@@ -775,7 +775,7 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: toSSML('foo'),
+        message: { speech: toSSML('foo') },
         quickReplies: ['one', 'two'],
       },
     );

--- a/output-googleassistantlegacy/test/strategy.test.ts
+++ b/output-googleassistantlegacy/test/strategy.test.ts
@@ -45,6 +45,7 @@ describe('toResponse', () => {
               {
                 simpleResponse: {
                   ssml: toSSML('foo'),
+                  displayText: 'foo',
                 },
               },
             ],
@@ -56,8 +57,8 @@ describe('toResponse', () => {
       return convertToResponseAndExpectToEqual(
         {
           message: {
-            text: 'foo',
-            displayText: 'bar',
+            speech: 'foo',
+            text: 'bar',
           },
         },
         {
@@ -86,7 +87,7 @@ describe('toResponse', () => {
         },
         {
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('bar') } }],
+            items: [{ simpleResponse: { ssml: toSSML('bar'), displayText: 'bar' } }],
           },
         },
       );
@@ -109,9 +110,9 @@ describe('toResponse', () => {
         },
         {
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
-          noInputPrompts: [{ ssml: toSSML('bar') }],
+          noInputPrompts: [{ ssml: toSSML('bar'), displayText: 'bar' }],
         },
       );
     });
@@ -120,13 +121,13 @@ describe('toResponse', () => {
         {
           message: 'foo',
           reprompt: {
-            text: 'bar',
-            displayText: 'test',
+            speech: 'bar',
+            text: 'test',
           },
         },
         {
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
           noInputPrompts: [{ ssml: toSSML('bar'), displayText: 'test' }],
         },
@@ -145,9 +146,9 @@ describe('toResponse', () => {
         },
         {
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
-          noInputPrompts: [{ ssml: toSSML('foo') }],
+          noInputPrompts: [{ ssml: toSSML('foo'), displayText: 'foo' }],
         },
       );
     });
@@ -170,7 +171,7 @@ describe('toResponse', () => {
         {
           expectUserResponse: false,
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -184,7 +185,7 @@ describe('toResponse', () => {
         {
           expectUserResponse: true,
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -203,7 +204,7 @@ describe('toResponse', () => {
         {
           expectUserResponse: false,
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -227,7 +228,7 @@ describe('toResponse', () => {
         }),
       ).toEqual({
         richResponse: {
-          items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+          items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           suggestions: quickReplies.slice(0, SUGGESTIONS_MAX_SIZE).map((title) => ({ title })),
         },
       });
@@ -241,7 +242,7 @@ describe('toResponse', () => {
         {
           richResponse: {
             suggestions: [{ title: 'hello' }, { title: 'world' }],
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -260,7 +261,7 @@ describe('toResponse', () => {
         {
           richResponse: {
             suggestions: [{ title: 'world' }],
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -300,7 +301,7 @@ describe('toResponse', () => {
         {
           richResponse: {
             items: [
-              { simpleResponse: { ssml: toSSML('foo') } },
+              { simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } },
               { basicCard: { title: 'foo', formattedText: 'bar' } },
             ],
           },
@@ -319,7 +320,7 @@ describe('toResponse', () => {
         {
           richResponse: {
             items: [
-              { simpleResponse: { ssml: toSSML('foo') } },
+              { simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } },
               {
                 basicCard: {
                   title: 'foo',
@@ -344,7 +345,7 @@ describe('toResponse', () => {
         {
           richResponse: {
             items: [
-              { simpleResponse: { ssml: toSSML('foo') } },
+              { simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } },
               {
                 basicCard: {
                   title: 'foo',
@@ -377,7 +378,7 @@ describe('toResponse', () => {
         {
           richResponse: {
             items: [
-              { simpleResponse: { ssml: toSSML('foo') } },
+              { simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } },
               {
                 basicCard: {
                   title: 'overwritten',
@@ -461,7 +462,7 @@ describe('toResponse', () => {
             },
           },
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -527,7 +528,7 @@ describe('toResponse', () => {
             },
           },
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -552,7 +553,7 @@ describe('toResponse', () => {
         {
           expectUserResponse: true,
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -611,7 +612,7 @@ describe('toResponse', () => {
         {
           systemIntent,
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -635,7 +636,7 @@ describe('toResponse', () => {
         {
           noInputPrompts,
           richResponse: {
-            items: [{ simpleResponse: { ssml: toSSML('foo') } }],
+            items: [{ simpleResponse: { ssml: toSSML('foo'), displayText: 'foo' } }],
           },
         },
       );
@@ -695,7 +696,7 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: 'foo',
+        message: toSSML('foo'),
         listen: true,
       },
     );
@@ -727,7 +728,7 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: 'foo',
+        message: toSSML('foo'),
         carousel: {
           items: [
             { key: 'one', title: 'one' },
@@ -753,8 +754,8 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: 'foo',
-        reprompt: 'foo',
+        message: toSSML('foo'),
+        reprompt: toSSML('foo'),
       },
     );
   });
@@ -774,7 +775,7 @@ describe('fromResponse', () => {
         },
       },
       {
-        message: 'foo',
+        message: toSSML('foo'),
         quickReplies: ['one', 'two'],
       },
     );

--- a/output-googlebusiness/README.md
+++ b/output-googlebusiness/README.md
@@ -62,13 +62,13 @@ Under the hood, Jovo translates the `message` into a text message ([see the offi
 }
 ```
 
-It is also possible to use `message` as an object which contains both a `text` (the *spoken* text on platforms like Alexa) and a `displayText` (*written* text to be displayed in chat bubbles). In this case, Google Business Messages uses the `displayText` element.
+It is also possible to use `message` as an object which contains both a `speech` (the *spoken* text on platforms like Alexa) and a `text` (*written* text to be displayed in chat bubbles). In this case, Google Business Messages uses the `text` element.
 
 ```typescript
 {
   message: {
-    text: 'Hello listener!',
-    displayText: 'Hello reader!'
+    speech: 'Hello listener!',
+    text: 'Hello reader!'
   }
 }
 ```

--- a/output-googlebusiness/src/GoogleBusinessOutputTemplateConverterStrategy.ts
+++ b/output-googlebusiness/src/GoogleBusinessOutputTemplateConverterStrategy.ts
@@ -174,7 +174,9 @@ export class GoogleBusinessOutputTemplateConverterStrategy extends MultipleRespo
 
   convertMessageToGoogleBusinessText(message: MessageValue): string {
     return removeSSML(
-      typeof message === 'string' ? message : message.toGoogleBusinessText?.() || message.text,
+      typeof message === 'string'
+        ? message
+        : message.toGoogleBusinessText?.() || message.text || message.speech,
     );
   }
 

--- a/output-googlebusiness/src/GoogleBusinessOutputTemplateConverterStrategy.ts
+++ b/output-googlebusiness/src/GoogleBusinessOutputTemplateConverterStrategy.ts
@@ -1,12 +1,10 @@
 import {
   Card,
   Carousel,
-  MessageValue,
   MultipleResponsesOutputTemplateConverterStrategy,
   OutputTemplate,
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
-  removeSSML,
 } from '@jovotech/output';
 import {
   CARD_CONTENT_DESCRIPTION_MAX_LENGTH,
@@ -17,6 +15,7 @@ import {
   SUGGESTIONS_MAX_SIZE,
 } from './constants';
 import { GoogleBusinessResponse, RepresentativeType, Suggestion } from './models';
+import { convertMessageToGoogleBusinessText } from './utilities';
 
 export class GoogleBusinessOutputTemplateConverterStrategy extends MultipleResponsesOutputTemplateConverterStrategy<
   GoogleBusinessResponse,
@@ -102,7 +101,7 @@ export class GoogleBusinessOutputTemplateConverterStrategy extends MultipleRespo
 
     const message = output.message;
     if (message) {
-      addResponse('text', this.convertMessageToGoogleBusinessText(message));
+      addResponse('text', convertMessageToGoogleBusinessText(message));
     }
 
     const card = output.card;
@@ -170,14 +169,6 @@ export class GoogleBusinessOutputTemplateConverterStrategy extends MultipleRespo
       output.quickReplies = response.suggestions.map((suggestion) => suggestion.toQuickReply!());
     }
     return output;
-  }
-
-  convertMessageToGoogleBusinessText(message: MessageValue): string {
-    return removeSSML(
-      typeof message === 'string'
-        ? message
-        : message.toGoogleBusinessText?.() || message.text || message.speech,
-    );
   }
 
   convertQuickReplyToGoogleBusinessSuggestion(quickReply: QuickReplyValue): Suggestion {

--- a/output-googlebusiness/src/index.ts
+++ b/output-googlebusiness/src/index.ts
@@ -58,3 +58,4 @@ export * from './models';
 export * from './constants';
 
 export * from './GoogleBusinessOutputTemplateConverterStrategy';
+export { convertMessageToGoogleBusinessText } from './utilities';

--- a/output-googlebusiness/src/utilities.ts
+++ b/output-googlebusiness/src/utilities.ts
@@ -1,4 +1,4 @@
-import { Card, Carousel, Message, QuickReply } from '@jovotech/output';
+import { Card, Carousel, Message, QuickReply, removeSSML } from '@jovotech/output';
 import { CardContent, CardWidth, MediaHeight } from './models';
 
 export function augmentModelPrototypes(): void {
@@ -51,7 +51,7 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toGoogleBusinessText = function () {
-    return this.text;
+    return removeSSML(this.text || this.speech);
   };
 
   QuickReply.prototype.toGoogleBusinessSuggestion = function () {

--- a/output-googlebusiness/src/utilities.ts
+++ b/output-googlebusiness/src/utilities.ts
@@ -1,5 +1,20 @@
-import { Card, Carousel, Message, QuickReply, removeSSML } from '@jovotech/output';
+import {
+  Card,
+  Carousel,
+  Message,
+  MessageValue,
+  QuickReply,
+  removeSSML,
+  SpeechMessage,
+  TextMessage,
+} from '@jovotech/output';
 import { CardContent, CardWidth, MediaHeight } from './models';
+
+export function convertMessageToGoogleBusinessText(message: MessageValue): string {
+  return removeSSML(
+    typeof message === 'string' ? message : message.text || (message.speech as string),
+  );
+}
 
 export function augmentModelPrototypes(): void {
   Card.prototype.toGoogleBusinessCardContent = function () {
@@ -51,7 +66,7 @@ export function augmentModelPrototypes(): void {
   };
 
   Message.prototype.toGoogleBusinessText = function () {
-    return removeSSML(this.text || this.speech);
+    return convertMessageToGoogleBusinessText(this as SpeechMessage | TextMessage);
   };
 
   QuickReply.prototype.toGoogleBusinessSuggestion = function () {

--- a/output/src/OutputTemplateConverterStrategy.ts
+++ b/output/src/OutputTemplateConverterStrategy.ts
@@ -115,12 +115,12 @@ export abstract class OutputTemplateConverterStrategy<
     offset = 0,
   ): MessageValue {
     const actualMaxLength = maxLength - offset;
-    const messageLength = typeof message === 'object' ? message.text.length : message.length;
+    const messageLength = typeof message === 'object' ? message.speech.length : message.length;
     if (!this.shouldSanitize('trimStrings') || messageLength <= actualMaxLength) {
       return message;
     }
     if (typeof message === 'object') {
-      message.text = message.text.slice(0, actualMaxLength);
+      message.speech = message.speech.slice(0, actualMaxLength);
     } else {
       message = message.slice(0, actualMaxLength);
     }

--- a/output/src/OutputTemplateConverterStrategy.ts
+++ b/output/src/OutputTemplateConverterStrategy.ts
@@ -114,16 +114,22 @@ export abstract class OutputTemplateConverterStrategy<
     maxLength: number,
     offset = 0,
   ): MessageValue {
-    const actualMaxLength = maxLength - offset;
-    const messageLength = typeof message === 'object' ? message.speech.length : message.length;
-    if (!this.shouldSanitize('trimStrings') || messageLength <= actualMaxLength) {
+    if (!this.shouldSanitize('trimStrings')) {
       return message;
     }
+
+    const actualMaxLength = maxLength - offset;
     if (typeof message === 'object') {
-      message.speech = message.speech.slice(0, actualMaxLength);
+      if (message.speech) {
+        message.speech = message.speech.slice(0, actualMaxLength);
+      }
+      if (message.text) {
+        message.text = message.text.slice(0, actualMaxLength);
+      }
     } else {
       message = message.slice(0, actualMaxLength);
     }
+
     this.logStringTrimWarning(path, maxLength);
     return message;
   }

--- a/output/src/decorators/transformation/TransformMessage.ts
+++ b/output/src/decorators/transformation/TransformMessage.ts
@@ -1,0 +1,13 @@
+import { Message, plainToClass, SpeechMessage, TextMessage, Transform } from '../..';
+
+export function TransformMessage(): PropertyDecorator {
+  return Transform(({ value }: { value: Message }) => {
+    if (value?.speech) {
+      return plainToClass(SpeechMessage, value);
+    }
+    if (value?.text) {
+      return plainToClass(TextMessage, value);
+    }
+    return plainToClass(Message, value);
+  }) as PropertyDecorator;
+}

--- a/output/src/models/Message.ts
+++ b/output/src/models/Message.ts
@@ -1,14 +1,33 @@
-import { IsNotEmpty, IsOptional, IsString } from '..';
+import { IsSomeValid, isString } from '..';
 
-export type MessageValue = string | Message;
+export type MessageValue = string | SpeechMessage | TextMessage;
+
+export const IsValidMessageString = () =>
+  IsSomeValid<Message>({
+    keys: ['speech', 'text'],
+    validate: (value, args) => {
+      if (!isString(value)) {
+        return '$property must be a string';
+      }
+      if (!value) {
+        return '$property should not be empty';
+      }
+      return;
+    },
+  });
 
 export class Message {
-  @IsString()
-  @IsNotEmpty()
-  speech: string;
+  @IsValidMessageString()
+  speech?: string;
 
-  @IsOptional()
-  @IsString()
-  @IsNotEmpty()
+  @IsValidMessageString()
   text?: string;
+}
+
+export class SpeechMessage extends Message {
+  speech: string;
+}
+
+export class TextMessage extends Message {
+  text: string;
 }

--- a/output/src/models/Message.ts
+++ b/output/src/models/Message.ts
@@ -5,10 +5,10 @@ export type MessageValue = string | Message;
 export class Message {
   @IsString()
   @IsNotEmpty()
-  text: string;
+  speech: string;
 
   @IsOptional()
   @IsString()
   @IsNotEmpty()
-  displayText?: string;
+  text?: string;
 }

--- a/output/src/models/OutputTemplateBase.ts
+++ b/output/src/models/OutputTemplateBase.ts
@@ -8,6 +8,7 @@ import {
   ListenValue,
   ValidateNested,
 } from '..';
+import { TransformMessage } from '../decorators/transformation/TransformMessage';
 import { IsStringOrInstance } from '../decorators/validation/IsStringOrInstance';
 import { Card } from './Card';
 import { Carousel } from './Carousel';
@@ -25,7 +26,7 @@ export class OutputTemplateBase {
 
   @IsOptional()
   @IsStringOrInstance(Message)
-  @Type(() => Message)
+  @TransformMessage()
   message?: MessageValue;
 
   @IsOptional()

--- a/output/src/models/PlatformOutputTemplate.ts
+++ b/output/src/models/PlatformOutputTemplate.ts
@@ -8,6 +8,7 @@ import {
   Type,
   ValidateNested,
 } from '..';
+import { TransformMessage } from '../decorators/transformation/TransformMessage';
 import { IsBooleanOrInstance } from '../decorators/validation/IsBooleanOrInstance';
 import { IsStringOrInstance } from '../decorators/validation/IsStringOrInstance';
 import { Card } from './Card';
@@ -27,7 +28,7 @@ export class PlatformOutputTemplate<
 
   @IsOptional()
   @IsStringOrInstance(Message)
-  @Type(() => Message)
+  @TransformMessage()
   message?: MessageValue | null;
 
   @IsOptional()

--- a/output/src/strategies/SingleResponseOutputTemplateConverterStrategy.ts
+++ b/output/src/strategies/SingleResponseOutputTemplateConverterStrategy.ts
@@ -127,29 +127,29 @@ export abstract class SingleResponseOutputTemplateConverterStrategy<
       return mergeWith;
     }
     if (typeof target === 'string' && typeof mergeWith === 'string') {
-      return this.mergeText(target, mergeWith);
+      return this.mergeSpeech(target, mergeWith);
     }
+    const targetSpeech = typeof target === 'string' ? target : target.speech;
     const targetText = typeof target === 'string' ? target : target.text;
-    const targetDisplayText = typeof target === 'string' ? target : target.displayText;
 
+    const mergeWithSpeech = typeof mergeWith === 'string' ? mergeWith : mergeWith.speech;
     const mergeWithText = typeof mergeWith === 'string' ? mergeWith : mergeWith.text;
-    const mergeWithDisplayText = typeof mergeWith === 'string' ? mergeWith : mergeWith.displayText;
 
-    const text = this.mergeText(targetText, mergeWithText);
+    const speech = this.mergeSpeech(targetSpeech, mergeWithSpeech);
 
-    if (!targetDisplayText && !mergeWithDisplayText) {
+    if (!targetText && !mergeWithText) {
       return {
-        text,
+        speech,
       };
     }
-    const displayText = this.mergeDisplayText(targetDisplayText, mergeWithDisplayText);
+    const text = this.mergeText(targetText, mergeWithText);
     return {
+      speech,
       text,
-      displayText,
     };
   }
 
-  protected mergeText(target: string, mergeWith: string): string {
+  protected mergeSpeech(target: string, mergeWith: string): string {
     const mergedText = [target, mergeWith].reduce((result, text) => {
       if (text) {
         result += `${result?.length ? ' ' : ''}${removeSSMLSpeakTags(text)}`;
@@ -159,7 +159,7 @@ export abstract class SingleResponseOutputTemplateConverterStrategy<
     return isSSML(target) || isSSML(mergeWith) ? toSSML(mergedText) : mergedText;
   }
 
-  protected mergeDisplayText(
+  protected mergeText(
     target: string | undefined,
     mergeWith: string | undefined,
   ): string | undefined {

--- a/output/test/SingleResponseOutputTemplateConverterStrategy.test.ts
+++ b/output/test/SingleResponseOutputTemplateConverterStrategy.test.ts
@@ -51,35 +51,35 @@ describe('prepareOutput', () => {
             reprompt: 'Hello',
           },
           {
-            message: { text: 'World!', displayText: 'World!' },
-            reprompt: { text: 'World!' },
+            message: { speech: 'World!', text: 'World!' },
+            reprompt: { speech: 'World!' },
           },
         ]);
         expect(preparedOutput).toEqual({
           message: {
+            speech: 'Hello World!',
             text: 'Hello World!',
-            displayText: 'Hello World!',
           },
           reprompt: {
-            text: 'Hello World!',
-            displayText: 'Hello',
+            speech: 'Hello World!',
+            text: 'Hello',
           },
         });
       });
       test('object + object passed', () => {
         const preparedOutput = strategy.prepareOutput([
           {
-            message: { text: 'Hello', displayText: 'Hello' },
-            reprompt: { text: 'Hello' },
+            message: { speech: 'Hello', text: 'Hello' },
+            reprompt: { speech: 'Hello' },
           },
           {
-            message: { text: 'World!' },
-            reprompt: { text: 'World!' },
+            message: { speech: 'World!' },
+            reprompt: { speech: 'World!' },
           },
         ]);
         expect(preparedOutput).toEqual({
-          message: { text: 'Hello World!', displayText: 'Hello' },
-          reprompt: { text: 'Hello World!' },
+          message: { speech: 'Hello World!', text: 'Hello' },
+          reprompt: { speech: 'Hello World!' },
         });
       });
 
@@ -96,19 +96,19 @@ describe('prepareOutput', () => {
           message: '<speak>Hello World!</speak>',
         });
       });
-      test('SSML removed for displayText', () => {
+      test('SSML removed for text', () => {
         const preparedOutput = strategy.prepareOutput([
           {
             message: '<speak>Hello</speak>',
           },
           {
-            message: { text: 'World!', displayText: 'World!' },
+            message: { speech: 'World!', text: 'World!' },
           },
         ]);
         expect(preparedOutput).toEqual({
           message: {
-            text: '<speak>Hello World!</speak>',
-            displayText: 'Hello World!',
+            speech: '<speak>Hello World!</speak>',
+            text: 'Hello World!',
           },
         });
       });

--- a/output/test/validation.test.ts
+++ b/output/test/validation.test.ts
@@ -90,9 +90,9 @@ describe('validation - QuickReply', () => {
 });
 
 describe('validation - Message', () => {
-  testStringProperty(Message, 'text');
-  testOptionalStringProperty(Message, 'displayText', {
-    text: 'foo',
+  testStringProperty(Message, 'speech');
+  testOptionalStringProperty(Message, 'text', {
+    speech: 'foo',
   });
 });
 
@@ -224,7 +224,7 @@ describe('validation - OutputTemplate', () => {
       OutputTemplate,
       {
         message: {
-          text: 'foo',
+          speech: 'foo',
         },
       },
       0,
@@ -237,7 +237,7 @@ describe('validation - OutputTemplate', () => {
       OutputTemplate,
       {
         reprompt: {
-          text: '',
+          speech: '',
         },
       },
       1,
@@ -248,7 +248,7 @@ describe('validation - OutputTemplate', () => {
       OutputTemplate,
       {
         reprompt: {
-          text: 'foo',
+          speech: 'foo',
         },
       },
       0,


### PR DESCRIPTION
- Rename property `text` of `Message` to `speech`
- Rename property `displayText` of `Message` to `text`
- The `Message`-object now consists of either `speech` (previously `text`) or `text` (previously `displayText`) or both
