### PR TITLE
👔 `listen` is now `true` by default

### DIFF
--- a/docs/output-templates.md
+++ b/docs/output-templates.md
@@ -24,7 +24,6 @@ And here is an example that asks the user a question and offers guidance how to 
 {
   message: 'Do you like pizza?',
   quickReplies: [ 'yes', 'no' ],
-  listen: true,
 }
 ```
 
@@ -36,16 +35,16 @@ Jovo output offers both [generic output](#generic-output-elements) as well as [p
 
 Jovo output templates come with a selection of generic elements that are supported by most platforms, including:
 
-* `message`
-* `reprompt`
-* `carousel`
-* `card`
-* `quickReplies`
-* `listen`
+* [`message`](#message)
+* [`reprompt`](#reprompt)
+* [`carousel`](#carousel)
+* [`card`](#card)
+* [`quickReplies`](#quickreplies)
+* [`listen`](#listen)
 
 Not all platforms support all of these elements. In such a case, the platform just ignores that element and still successfully builds the rest of the output template.
 
-### Message
+### message
 
 The `message` is usually either what you hear (speech output) or what see you see in the form of a chat bubble.
 
@@ -66,7 +65,7 @@ A `message` can either be a `string` or have the following properties:
 }
 ```
 
-### Reprompt
+### reprompt
 
 The `reprompt` is typically only relevant for voice interfaces. It represents the output that is presented to the user if they haven't responded to a previous question.
 
@@ -80,7 +79,7 @@ The `reprompt` is typically only relevant for voice interfaces. It represents th
 A `reprompt` can have the same values (`text`, `displayText`) as a [`message`](#message).
 
 
-### Card
+### card
 
 Cards are often used to display content in a visual and structured way.
 
@@ -103,7 +102,7 @@ A `card` consists of the following properties:
 * `imageAlt`
 
 
-### Carousel
+### carousel
 
 A carousel is a (usually horizontally scrollable) collection of at least 2 [cards](#card).
 
@@ -129,7 +128,7 @@ A `carousel` consists of the following properties:
 * `title`
 * `items`: An array of [card](#card) items
 
-### Quick Replies
+### quickReplies
 
 Quick replies (sometimes called *suggestion chips*) are little buttons that provide suggestions for the user to tap instead of having to type out a response to a question.
 
@@ -175,14 +174,16 @@ Usually, the `value` of the quick reply gets passed to a platform's natural lang
 }
 ```
 
-### Listen
+### listen
 
-Especially for voice platforms, it is important to indicate that you are expecting the user to answer. You can do this by setting `listen` to `true`. The platform will then leave the microphone open.
+Especially for voice platforms, it is important to indicate whether you are expecting the user to answer (keep the microphone open) or want the session to close. The `listen` property is used for this. By default, it is set to `true`, even if you don't specify it in your output template. 
+
+If you want the session to close, you need to set it to `false`:
 
 ```typescript
 {
-  message: `Hello world! What's your name?`,
-  listen: true,
+  message: `Goodbye!`,
+  listen: false,
 }
 ```
 

--- a/output-alexa/README.md
+++ b/output-alexa/README.md
@@ -76,7 +76,6 @@ The [generic `reprompt` element](https://v4.jovo.tech/docs/output-templates#mess
 {
   message: `Hello world! What's your name?`,
   reprompt: 'Could you tell me your name?',
-  listen: true,
 }
 ```
 
@@ -93,19 +92,20 @@ Under the hood, Jovo translates the `reprompt` into an `outputSpeech` object ([s
 }
 ```
 
-**Note**: For Alexa to wait for a user to answer a question, the [listen property](#listen) needs to be added.
-
 ### listen
 
-The [`listen` element](https://v4.jovo.tech/docs/output-templates#listen)  needs to be added to tell Alexa that it should keep the microphone open and wait for a user's response.
+The [`listen` element](https://v4.jovo.tech/docs/output-templates#listen)  determines if Alexa should keep the microphone open and wait for a user's response.
+
+By default (if you don't specify it otherwise in the template), `listen` is set to `true`. If you want to close a session after a response, you need to set it to `false`:
 
 ```typescript
 {
-  listen: true,
+  message: `Goodbye!`,
+  listen: false,
 }
 ```
 
-Under the hood, Jovo translates `listen: true` to `"shouldEndSession": false` in the JSON response.
+Under the hood, Jovo translates `listen: false` to `"shouldEndSession": true` in the JSON response.
 
 The `listen` element can also be used to add dynamic entities for Alexa. [Learn more in the `$entities` documentation](https://v4.jovo.tech/docs/entities#dynamic-entities).
 

--- a/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
+++ b/output-alexa/src/AlexaOutputTemplateConverterStrategy.ts
@@ -92,25 +92,22 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
       response.response.directives.push(...directives);
     };
 
-    const listen = output.listen;
-    if (typeof listen !== 'undefined') {
-      response.response.shouldEndSession = !listen;
-
-      if (typeof listen === 'object' && listen.entities) {
-        const directive = new DialogUpdateDynamicEntitiesDirective();
-        if (listen.entities.mode === DynamicEntitiesMode.Clear) {
-          directive.updateBehavior = DynamicEntitiesUpdateBehavior.Clear;
-        } else if (listen.entities.types) {
-          directive.updateBehavior = DynamicEntitiesUpdateBehavior.Replace;
-          directive.types = Object.keys(listen.entities.types).map((entityName) =>
-            this.convertDynamicEntityToSlotType(
-              entityName,
-              ((listen.entities as DynamicEntities).types as DynamicEntityMap)[entityName],
-            ),
-          );
-        }
-        addToDirectives(directive);
+    const listen = output.listen ?? true;
+    response.response.shouldEndSession = !listen;
+    if (typeof listen === 'object' && listen.entities) {
+      const directive = new DialogUpdateDynamicEntitiesDirective();
+      if (listen.entities.mode === DynamicEntitiesMode.Clear) {
+        directive.updateBehavior = DynamicEntitiesUpdateBehavior.Clear;
+      } else if (listen.entities.types) {
+        directive.updateBehavior = DynamicEntitiesUpdateBehavior.Replace;
+        directive.types = Object.keys(listen.entities.types).map((entityName) =>
+          this.convertDynamicEntityToSlotType(
+            entityName,
+            ((listen.entities as DynamicEntities).types as DynamicEntityMap)[entityName],
+          ),
+        );
       }
+      addToDirectives(directive);
     }
 
     const message = output.message;

--- a/output-core/src/CoreOutputTemplateConverterStrategy.ts
+++ b/output-core/src/CoreOutputTemplateConverterStrategy.ts
@@ -31,17 +31,23 @@ export class CoreOutputTemplateConverterStrategy extends OutputTemplateConverter
         },
       },
     };
-    let lastListen: ListenValue | undefined;
+    let mergedListen: ListenValue | undefined;
     output.forEach((outputItem) => {
-      const listen = outputItem.platforms?.core?.listen ?? outputItem.listen;
-      if (typeof listen === 'boolean' || typeof listen === 'object') {
-        lastListen = listen;
+      const listen = outputItem.listen ?? true;
+
+      // if listen is an object and not null
+      if (typeof listen === 'object' && listen) {
+        mergedListen = { ...listen };
+        // if merged listen is not an object
+      } else if (typeof mergedListen !== 'object') {
+        mergedListen = listen;
       }
+
       if (outputItem.platforms?.core?.nativeResponse) {
         mergeInstances(response, outputItem.platforms.core.nativeResponse);
       }
     });
-    response.context.session.end = !lastListen;
+    response.context.session.end = !mergedListen;
     return response;
   }
 

--- a/output-googleassistant/README.md
+++ b/output-googleassistant/README.md
@@ -114,15 +114,18 @@ Under the hood, Jovo translates the `reprompt` into `NO_INPUT_1`, `NO_INPUT_2`, 
 
 ### listen
 
-The [`listen` element](https://v4.jovo.tech/docs/output-templates#listen) needs to be added to tell Google Assistant that it should keep the microphone open and wait for a user's response.
+The [`listen` element](https://v4.jovo.tech/docs/output-templates#listen)  determines if Google Assistant should keep the microphone open and wait for a user's response.
+
+By default (if you don't specify it otherwise in the template), `listen` is set to `true`. If you want to close a session after a response, you need to set it to `false`:
 
 ```typescript
 {
-  listen: true,
+  message: `Goodbye!`,
+  listen: false,
 }
 ```
 
-If `listen` is not set to `true`, Jovo transitions to the `actions.scene.END_CONVERSATION` under the hood.
+If `listen` is set to `false`, Jovo sets the `expectUserResponse` in the Google Assistant response to `false`.
 
 The `listen` element can also be used to add dynamic entities, called type overrides in Google Assistant. [Learn more in the `$entities` documentation](https://v4.jovo.tech/docs/entities#dynamic-entities).
 

--- a/output-googleassistantlegacy/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistantlegacy/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -82,11 +82,8 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       },
     };
 
-    // TODO: fully determine when to set listen
-    const listen = output.listen;
-    if (typeof listen !== 'undefined') {
-      response.expectUserResponse = !!listen;
-    }
+    const listen = output.listen ?? true;
+    response.expectUserResponse = !!listen;
 
     const message = output.message;
     if (message) {


### PR DESCRIPTION
`listen` is now `true` if no `listen` was set.  This applies to all platforms that use `listen`.