### PR TITLE
🚑  Replace accidentally added placeholder methods with correct implementations

### DIFF
--- a/output-dialogflow/src/DialogflowOutputTemplateConverterStrategy.ts
+++ b/output-dialogflow/src/DialogflowOutputTemplateConverterStrategy.ts
@@ -16,8 +16,8 @@ import {
   EntityOverrideMode,
   EntityOverrideModeLike,
   SessionEntityType,
-  Text,
 } from './models';
+import { convertMessageToDialogflowText } from './utilities';
 
 // TODO CHECK: Theoretically, multiple messages are supported in the response, in the future this could be refactored for that.
 export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOutputTemplateConverterStrategy<
@@ -82,7 +82,7 @@ export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOut
       }
       response.fulfillment_messages.push({
         message: {
-          text: convertMessageToText(message),
+          text: convertMessageToDialogflowText(message),
         },
       });
     }
@@ -199,7 +199,4 @@ export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOut
       })),
     };
   }
-}
-function convertMessageToText(message: MessageValue): Text | undefined {
-  throw new Error('Function not implemented.');
 }

--- a/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/output-googleassistant/src/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -21,12 +21,12 @@ import {
 import {
   GoogleAssistantResponse,
   Session,
-  Simple,
   Suggestion,
   TypeOverride,
   TypeOverrideMode,
   TypeOverrideModeLike,
 } from './models';
+import { convertMessageToGoogleAssistantSimple } from './utilities';
 
 export class GoogleAssistantOutputTemplateConverterStrategy extends SingleResponseOutputTemplateConverterStrategy<
   GoogleAssistantResponse,
@@ -120,7 +120,7 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       if (!response.prompt) {
         response.prompt = {};
       }
-      response.prompt.firstSimple = convertMessageToSimple(message);
+      response.prompt.firstSimple = convertMessageToGoogleAssistantSimple(message);
     }
 
     const reprompt = output.reprompt;
@@ -293,7 +293,4 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
       })),
     };
   }
-}
-function convertMessageToSimple(message: MessageValue): Simple | undefined {
-  throw new Error('Function not implemented.');
 }


### PR DESCRIPTION
When refactoring the code, Webstorm accidentally added placeholder implementations instead of importing the method. This also happened due to naming inconsistencies.