### PR TITLE
👔 Update logic for merging `listen`

### DIFF
--- a/docs/output-templates.md
+++ b/docs/output-templates.md
@@ -209,6 +209,7 @@ It's also possible to turn `listen` into an object to tell the platform to liste
 
 [Learn more about dynamic entities in the entities documentation](https://v4.jovo.tech/docs/entities).
 
+In the case that your output is an [array of objects](#array-of-output-templates) with differing `listen` values, the one of the last array will be prioritized. The only exception is that a `listen: true` value does not override dynamic entities, because setting dynamic entities implicitly sets `listen` to `true`. A last item in an array with `listen: false` closes the session and removes previous dynamic entities.
 
 ## Platform Specific Output Elements
 
@@ -285,7 +286,7 @@ For each platform, you can add a `nativeResponse` object that is directly transl
 }
 ```
 
-## Multiple Responses
+## Array of Output Templates
 
 You can also have an array of output objects:
 
@@ -333,3 +334,4 @@ If the [`message`](#message) is an object for one of the output objects, the oth
 }
 ```
 
+For elements that are only allowed once per response (like [`card`](#card) or [`carousel`](#carousel)), the last object of the array will be prioritized, overriding previous elements.

--- a/output-core/src/CoreOutputTemplateConverterStrategy.ts
+++ b/output-core/src/CoreOutputTemplateConverterStrategy.ts
@@ -1,7 +1,7 @@
 import {
-  Listen,
   ListenValue,
   mergeInstances,
+  mergeListen,
   OutputTemplate,
   OutputTemplateConverterStrategy,
   OutputTemplateConverterStrategyConfig,
@@ -33,29 +33,14 @@ export class CoreOutputTemplateConverterStrategy extends OutputTemplateConverter
       },
     }) as CoreResponse;
 
-    let mergedListen: ListenValue = true;
-
+    let mergedListen: ListenValue | undefined | null;
     output.forEach((outputItem) => {
-      const canSetListenObject =
-        outputItem.listen !== false && typeof outputItem === 'object' && outputItem;
-      const canSetListenRest =
-        outputItem.listen !== false &&
-        !(typeof outputItem.listen === 'object' && outputItem.listen) &&
-        typeof outputItem !== 'undefined';
-
-      if (outputItem.listen === false) {
-        mergedListen = false;
-      } else if (canSetListenObject) {
-        mergedListen = { ...(outputItem.listen as Listen) };
-      } else if (canSetListenRest) {
-        mergedListen = outputItem.listen as boolean;
-      }
-
+      mergedListen = mergeListen(mergedListen, outputItem.listen);
       if (outputItem.platforms?.core?.nativeResponse) {
         mergeInstances(response, outputItem.platforms.core.nativeResponse);
       }
     });
-    response.context.session.end = !mergedListen;
+    response.context.session.end = !(mergedListen ?? true);
     return response;
   }
 

--- a/output-core/src/CoreOutputTemplateConverterStrategy.ts
+++ b/output-core/src/CoreOutputTemplateConverterStrategy.ts
@@ -1,4 +1,5 @@
 import {
+  Listen,
   ListenValue,
   mergeInstances,
   OutputTemplate,
@@ -31,16 +32,23 @@ export class CoreOutputTemplateConverterStrategy extends OutputTemplateConverter
         },
       },
     }) as CoreResponse;
-    let mergedListen: ListenValue | undefined;
-    output.forEach((outputItem) => {
-      const listen = outputItem.listen ?? true;
 
-      // if listen is an object and not null
-      if (typeof listen === 'object' && listen) {
-        mergedListen = { ...listen };
-        // if merged listen is not an object
-      } else if (typeof mergedListen !== 'object') {
-        mergedListen = listen;
+    let mergedListen: ListenValue = true;
+
+    output.forEach((outputItem) => {
+      const canSetListenObject =
+        outputItem.listen !== false && typeof outputItem === 'object' && outputItem;
+      const canSetListenRest =
+        outputItem.listen !== false &&
+        !(typeof outputItem.listen === 'object' && outputItem.listen) &&
+        typeof outputItem !== 'undefined';
+
+      if (outputItem.listen === false) {
+        mergedListen = false;
+      } else if (canSetListenObject) {
+        mergedListen = { ...(outputItem.listen as Listen) };
+      } else if (canSetListenRest) {
+        mergedListen = outputItem.listen as boolean;
       }
 
       if (outputItem.platforms?.core?.nativeResponse) {

--- a/output/src/strategies/SingleResponseOutputTemplateConverterStrategy.ts
+++ b/output/src/strategies/SingleResponseOutputTemplateConverterStrategy.ts
@@ -2,6 +2,7 @@ import {
   isSSML,
   Listen,
   mergeInstances,
+  mergeListen,
   MessageValue,
   NullableOutputTemplateBase,
   OutputTemplate,
@@ -28,7 +29,7 @@ import { OutputTemplateConverterStrategy } from '../OutputTemplateConverterStrat
  */
 export abstract class SingleResponseOutputTemplateConverterStrategy<
   RESPONSE extends Record<string, unknown>,
-  CONFIG extends OutputTemplateConverterStrategyConfig
+  CONFIG extends OutputTemplateConverterStrategyConfig,
 > extends OutputTemplateConverterStrategy<RESPONSE, CONFIG> {
   prepareOutput(output: OutputTemplate | OutputTemplate[]): OutputTemplate {
     output = super.prepareOutput(output);
@@ -117,21 +118,7 @@ export abstract class SingleResponseOutputTemplateConverterStrategy<
       target.carousel = { ...carousel };
     }
 
-    const listen = mergeWith.listen;
-
-    const canSetListenObject = target.listen !== false && typeof listen === 'object' && listen;
-    const canSetListenRest =
-      target.listen !== false &&
-      !(typeof target.listen === 'object' && target.listen) &&
-      typeof listen !== 'undefined';
-
-    if (listen === false) {
-      target.listen = false;
-    } else if (canSetListenObject) {
-      target.listen = { ...(listen as Listen) };
-    } else if (canSetListenRest) {
-      target.listen = listen;
-    }
+    target.listen = mergeListen(target.listen, mergeWith.listen);
   }
 
   protected mergeMessages(

--- a/output/src/strategies/SingleResponseOutputTemplateConverterStrategy.ts
+++ b/output/src/strategies/SingleResponseOutputTemplateConverterStrategy.ts
@@ -1,6 +1,5 @@
 import {
   isSSML,
-  Listen,
   mergeInstances,
   mergeListen,
   MessageValue,
@@ -24,8 +23,8 @@ import { OutputTemplateConverterStrategy } from '../OutputTemplateConverterStrat
  * - Strings get concatenated and separated by a whitespace.
  * - Quick Replies get merged into a single array.
  * - Card/Carousel the last in the array is used.
- * - nativeResponses get merged.
- * - Listen gets chosen by priority: false > object > true
+ * - NativeResponses get merged.
+ * - Listen gets merged.
  */
 export abstract class SingleResponseOutputTemplateConverterStrategy<
   RESPONSE extends Record<string, unknown>,

--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -134,24 +134,19 @@ export function mergeInstances<D extends object, S extends any[]>(
   );
 }
 
-/**
- * Merges listen by priority: false > object > rest
- */
 export function mergeListen(
   target: ListenValue | null | undefined,
   mergeWith: ListenValue | null | undefined,
 ): ListenValue | null | undefined {
-  const canSetListenObject = target !== false && typeof mergeWith === 'object' && mergeWith;
-  const canSetListenRest =
-    target !== false && !(typeof target === 'object' && target) && typeof mergeWith !== 'undefined';
-  if (mergeWith === false) {
-    return false;
+  // if target is an object and not null and mergeWith is true, target should not be overwritten
+  if (typeof target === 'object' && target && mergeWith === true) {
+    return target;
   }
-  if (canSetListenObject) {
-    return { ...(mergeWith as Listen) };
+  // if mergeWith is not undefined, target should become mergeWith
+  if (typeof mergeWith !== 'undefined') {
+    // if mergeWith is an object and not null, just return a copy of mergeWith, otherwise return mergeWith
+    return typeof mergeWith === 'object' && mergeWith ? { ...mergeWith } : mergeWith;
   }
-  if (canSetListenRest) {
-    return mergeWith;
-  }
+  // if mergeWith is undefined, just return target
   return target;
 }

--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import _merge from 'lodash.merge';
 import type { A, O } from 'ts-toolbelt';
-import { IsOptional, ValidateNested, ValidationError } from '.';
+import { IsOptional, Listen, ListenValue, ValidateNested, ValidationError } from '.';
 import { OutputTemplatePlatforms } from './models/OutputTemplatePlatforms';
 
 export function registerOutputPlatform<TYPE extends Record<string, unknown>>(
@@ -132,4 +132,26 @@ export function mergeInstances<D extends object, S extends any[]>(
     instanceToObject(destination),
     ...sources.map((source) => instanceToObject(source)),
   );
+}
+
+/**
+ * Merges listen by priority: false > object > rest
+ */
+export function mergeListen(
+  target: ListenValue | null | undefined,
+  mergeWith: ListenValue | null | undefined,
+): ListenValue | null | undefined {
+  const canSetListenObject = target !== false && typeof mergeWith === 'object' && mergeWith;
+  const canSetListenRest =
+    target !== false && !(typeof target === 'object' && target) && typeof mergeWith !== 'undefined';
+  if (mergeWith === false) {
+    return false;
+  }
+  if (canSetListenObject) {
+    return { ...(mergeWith as Listen) };
+  }
+  if (canSetListenRest) {
+    return mergeWith;
+  }
+  return target;
 }

--- a/output/test/SingleResponseOutputTemplateConverterStrategy.test.ts
+++ b/output/test/SingleResponseOutputTemplateConverterStrategy.test.ts
@@ -118,14 +118,14 @@ describe('prepareOutput', () => {
       });
     });
 
-    describe('listen is chosen by priority', () => {
-      test('false > object', () => {
+    describe('listen is merged', () => {
+      test('true + false = false', () => {
         const preparedOutput = strategy.prepareOutput([
           {
-            listen: false,
+            listen: true,
           },
           {
-            listen: { entities: {} },
+            listen: false,
           },
         ]);
         expect(preparedOutput).toEqual({
@@ -133,10 +133,38 @@ describe('prepareOutput', () => {
         });
       });
 
-      test('object > true', () => {
+      test('false + true = true', () => {
         const preparedOutput = strategy.prepareOutput([
           {
+            listen: false,
+          },
+          {
             listen: true,
+          },
+        ]);
+        expect(preparedOutput).toEqual({
+          listen: true,
+        });
+      });
+
+      test('object + false = false', () => {
+        const preparedOutput = strategy.prepareOutput([
+          {
+            listen: { entities: {} },
+          },
+          {
+            listen: false,
+          },
+        ]);
+        expect(preparedOutput).toEqual({
+          listen: false,
+        });
+      });
+
+      test('false + object = object', () => {
+        const preparedOutput = strategy.prepareOutput([
+          {
+            listen: false,
           },
           {
             listen: { entities: {} },
@@ -147,21 +175,36 @@ describe('prepareOutput', () => {
         });
       });
 
-      test('true > undefined', () => {
+      test('true + object = object', () => {
         const preparedOutput = strategy.prepareOutput([
           {
             listen: true,
           },
-          {},
+          {
+            listen: { entities: {} },
+          },
         ]);
         expect(preparedOutput).toEqual({
-          listen: true,
+          listen: {
+            entities: {},
+          },
         });
       });
 
-      test('stays undefined', () => {
-        const preparedOutput = strategy.prepareOutput([{}, {}]);
-        expect(preparedOutput).toEqual({});
+      test('special case - object + true = object', () => {
+        const preparedOutput = strategy.prepareOutput([
+          {
+            listen: { entities: {} },
+          },
+          {
+            listen: true,
+          },
+        ]);
+        expect(preparedOutput).toEqual({
+          listen: {
+            entities: {},
+          },
+        });
       });
     });
 


### PR DESCRIPTION
Previously, the priority for `listen` when merging was the following: object > any. 
Now, the order matters. Merging happens normally except for the special case when an object is merged with `true`, there the result will be the object. 