### PR TITLE
🐛 Fix bug that would cause response to not get mutated when merging with native response

### DIFF
--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -127,5 +127,5 @@ export function mergeInstances<D extends object, S extends any[]>(
   destination: D,
   ...sources: S
 ): O.MergeAll<D, S, 'deep'> {
-  return _merge(destination, ...sources);
+  return _merge(destination, ...sources.map((source) => instanceToObject(source)));
 }

--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -126,10 +126,6 @@ export function instanceToObject<T>(instance: T): T {
 export function mergeInstances<D extends object, S extends any[]>(
   destination: D,
   ...sources: S
-): O.MergeAll<OmitIndex<D, string>, S, 'deep'> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return _merge(
-    instanceToObject(destination),
-    ...sources.map((source) => instanceToObject(source)),
-  );
+): O.MergeAll<D, S, 'deep'> {
+  return _merge(destination, ...sources);
 }


### PR DESCRIPTION
Due to calling `instanceToObject` the reference gets lost when merging and the destination is not mutated.

Back when this was implemented I thought there was undesired behavior when merging an instance with a plain object via lodash.merge, but it seems that the error was somewhere else because this works as expected now.